### PR TITLE
Data types conversion fixes, CKAN resource naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 |Parameter                                       |Description                                                              |
 |------------------------------------------------|-------------------------------------------------------------------------|
-|**Resource name**                               |Name of CKAN resource to be created
+|**CKAN resource name**                          |Name of CKAN resource to be created                                      |
 |**Overwrite existing resources***               |If resource already exists, it will be rewritten.                        |
 
 ***
@@ -45,7 +45,7 @@ In order to work properly, this DPU needs configuration parameters properly set 
 
 |Version          |Release notes               |
 |-----------------|----------------------------|
-|1.1.0            | Resource name in CKAN is now configured by user; Only one table can be processed by DPU
+|1.1.0            | Resource name in CKAN is now configured by user; Only one table can be processed by DPU |
 |1.0.1            | bug fixes and update in build dependencies |
 |1.0.0            | First version              |
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 
 |Parameter                                       |Description                                                              |
 |------------------------------------------------|-------------------------------------------------------------------------|
+|**Resource name**                               |Name of CKAN resource to be created
 |**Overwrite existing resources***               |If resource already exists, it will be rewritten.                        |
 
 ***
@@ -44,6 +45,7 @@ In order to work properly, this DPU needs configuration parameters properly set 
 
 |Version          |Release notes               |
 |-----------------|----------------------------|
+|1.1.0            | Resource name in CKAN is now configured by user; Only one table can be processed by DPU
 |1.0.1            | bug fixes and update in build dependencies |
 |1.0.0            | First version              |
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
 	<groupId>org.opendatanode.plugins</groupId>
 	<artifactId>uv-l-relationalToCkan</artifactId>
-	<version>1.0.1</version>
+	<version>1.1.0</version>
 	<packaging>bundle</packaging>
 	<name>L-RelationalToCkan</name>
 	<description>Loads relational data into CKAN datastore using CKAN API and thin proxy</description>

--- a/src/main/java/eu/unifiedviews/plugins/loader/relationaltockan/RelationalToCkanConfig_V1.java
+++ b/src/main/java/eu/unifiedviews/plugins/loader/relationaltockan/RelationalToCkanConfig_V1.java
@@ -6,6 +6,8 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 public class RelationalToCkanConfig_V1 {
 
     private boolean bOverwriteTables = false;
+    
+    private String resourceName;
 
     public void setOverWriteTables(boolean overwrite) {
         this.bOverwriteTables = overwrite;
@@ -19,4 +21,13 @@ public class RelationalToCkanConfig_V1 {
     public String toString() {
         return ToStringBuilder.reflectionToString(this, ToStringStyle.SIMPLE_STYLE).toString();
     }
+
+    public String getResourceName() {
+        return resourceName;
+    }
+
+    public void setResourceName(String resourceName) {
+        this.resourceName = resourceName;
+    }
+    
 }

--- a/src/main/java/eu/unifiedviews/plugins/loader/relationaltockan/RelationalToCkanVaadinDialog.java
+++ b/src/main/java/eu/unifiedviews/plugins/loader/relationaltockan/RelationalToCkanVaadinDialog.java
@@ -15,7 +15,7 @@ public class RelationalToCkanVaadinDialog extends AbstractDialog<RelationalToCka
     private VerticalLayout mainLayout;
 
     private CheckBox chckOverWriteTables;
-    
+
     private TextField txtResourceName;
 
     public RelationalToCkanVaadinDialog() {
@@ -24,19 +24,23 @@ public class RelationalToCkanVaadinDialog extends AbstractDialog<RelationalToCka
 
     @Override
     protected void buildDialogLayout() {
+        setWidth("100%");
+        setHeight("100%");
+
         this.mainLayout = new VerticalLayout();
         this.mainLayout.setWidth("100%");
         this.mainLayout.setHeight("-1px");
         this.mainLayout.setSpacing(true);
-        this.mainLayout.setMargin(false);
+        this.mainLayout.setMargin(true);
 
         this.txtResourceName = new TextField();
         this.txtResourceName.setNullRepresentation("");
         this.txtResourceName.setRequired(true);
         this.txtResourceName.setCaption(this.ctx.tr("dialog.ckan.resource.name"));
         this.txtResourceName.setWidth("100%");
+        this.txtResourceName.setDescription(this.ctx.tr("dialog.resource.name.help"));
         this.mainLayout.addComponent(this.txtResourceName);
-        
+
         this.chckOverWriteTables = new CheckBox();
         this.chckOverWriteTables.setCaption(this.ctx.tr("dialog.ckan.overwrite"));
         this.mainLayout.addComponent(this.chckOverWriteTables);

--- a/src/main/java/eu/unifiedviews/plugins/loader/relationaltockan/RelationalToCkanVaadinDialog.java
+++ b/src/main/java/eu/unifiedviews/plugins/loader/relationaltockan/RelationalToCkanVaadinDialog.java
@@ -2,6 +2,7 @@ package eu.unifiedviews.plugins.loader.relationaltockan;
 
 import com.vaadin.ui.CheckBox;
 import com.vaadin.ui.Panel;
+import com.vaadin.ui.TextField;
 import com.vaadin.ui.VerticalLayout;
 
 import eu.unifiedviews.dpu.config.DPUConfigException;
@@ -14,6 +15,8 @@ public class RelationalToCkanVaadinDialog extends AbstractDialog<RelationalToCka
     private VerticalLayout mainLayout;
 
     private CheckBox chckOverWriteTables;
+    
+    private TextField txtResourceName;
 
     public RelationalToCkanVaadinDialog() {
         super(RelationalToCkan.class);
@@ -27,6 +30,13 @@ public class RelationalToCkanVaadinDialog extends AbstractDialog<RelationalToCka
         this.mainLayout.setSpacing(true);
         this.mainLayout.setMargin(false);
 
+        this.txtResourceName = new TextField();
+        this.txtResourceName.setNullRepresentation("");
+        this.txtResourceName.setRequired(true);
+        this.txtResourceName.setCaption(this.ctx.tr("dialog.ckan.resource.name"));
+        this.txtResourceName.setWidth("100%");
+        this.mainLayout.addComponent(this.txtResourceName);
+        
         this.chckOverWriteTables = new CheckBox();
         this.chckOverWriteTables.setCaption(this.ctx.tr("dialog.ckan.overwrite"));
         this.mainLayout.addComponent(this.chckOverWriteTables);
@@ -40,12 +50,18 @@ public class RelationalToCkanVaadinDialog extends AbstractDialog<RelationalToCka
     @Override
     protected void setConfiguration(RelationalToCkanConfig_V1 config) throws DPUConfigException {
         this.chckOverWriteTables.setValue(config.isOverWriteTables());
+        this.txtResourceName.setValue(config.getResourceName());
     }
 
     @Override
     protected RelationalToCkanConfig_V1 getConfiguration() throws DPUConfigException {
+        boolean isValid = this.txtResourceName.isValid();
+        if (!isValid) {
+            throw new DPUConfigException(ctx.tr("dialog.errors.params"));
+        }
         RelationalToCkanConfig_V1 config = new RelationalToCkanConfig_V1();
         config.setOverWriteTables(this.chckOverWriteTables.getValue());
+        config.setResourceName(this.txtResourceName.getValue());
 
         return config;
     }

--- a/src/main/resources/about.html
+++ b/src/main/resources/about.html
@@ -12,6 +12,8 @@ Also, prior to running this DPU, an association between pipeline and CKAN datase
 <p/>
 List of options:
 <ul>
+	<li><b>CKAN resource name</b> - (required) Name of resource to be created in CKAN. It should not change between pipeline runs as this name
+	is used as key to CKAN.
     <li><b>Overwrite existing resources</b> - (default false) if true and resource with the same name already exists in associated 
     dataset, it is overwritten. By default nothing happens if already exists, just warning message</li>
 </ul>

--- a/src/main/resources/resources.properties
+++ b/src/main/resources/resources.properties
@@ -2,6 +2,7 @@
 dialog.ckan.overwrite = Overwrite existing resources
 dialog.ckan.resource.name = CKAN resource name
 dialog.errors.params = Required configuration parameters missing
+dialog.resource.name.help = This name should not change between pipeline runs as it is used as key to CKAN. If name changes, existing resource in CKAN will not be updated and new resource will be created
 
 # Messages
 dpu.ckan.starting = {0} is starting.

--- a/src/main/resources/resources.properties
+++ b/src/main/resources/resources.properties
@@ -1,22 +1,23 @@
 # Dialog
-dialog.ckan.apilocation = Catalog API location
-dialog.ckan.pipelineid = Pipeline ID
 dialog.ckan.overwrite = Overwrite existing resources
+dialog.ckan.resource.name = CKAN resource name
+dialog.errors.params = Required configuration parameters missing
 
 # Messages
 dpu.ckan.starting = {0} is starting.
-dpu.resource.created = Resource and datastore for table {0} were created
-dpu.resource.updated = Resource and datastore for table {0} were updated 
+dpu.resource.created = Resource and datastore {0} were created
+dpu.resource.updated = Resource and datastore {0} were updated 
 
 # Errors
 errors.dpu.failed = Execution of DPU failed
 errors.tables.iterator = Failed to obtain input database tables
-dpu.resource.skipped.short = Creating resource for table {0} skipped
+dpu.resource.skipped.short = Creating resource {0} skipped
 dpu.resource.skipped.long = Resource was skipped because it already exists in the catalog and overwrite mode is not enabled
-dpu.resource.upload = Failed to create resource and datastore for database table {0}
+dpu.resource.upload = Failed to create resource and datastore {0} for database table {1}
 errors.dpu.upload = Internal error occurred during creating catalog resources from internal database tables 
 errors.dpu.dataset = Failed to obtain list of existing resources for the pipeline
 dpu.resource.dataseterror = Could not obtain Dataset entity from CKAN. Response: {0}
 errors.token.missing = Missing authentication token for catalog API
 errors.api.missing = Missing catalog API location URL
+errors.input.tables = Invalid count of input tables. DPU can process only one table
 dpu.resource.responseerror = CKAN responded that operation was not successful. See logs for error details

--- a/src/main/resources/resources_sk.properties
+++ b/src/main/resources/resources_sk.properties
@@ -1,22 +1,24 @@
 # Dialog
-dialog.ckan.apilocation = Lokácia API katalógu
-dialog.ckan.pipelineid = ID procesu
 dialog.ckan.overwrite = Prepísa\u0165 existujúce zdroje
+dialog.ckan.resource.name = Názov zdroja v CKANe
+dialog.errors.params = Chýbajú povinné konfigura\u010Dné parametre
+
 
 # Messages
 dpu.ckan.starting = {0} \u0161tartuje.
-dpu.resource.created = Zdroj a datastore pre tabu\u013Eku {0} boli vytvorené
-dpu.resource.updated = Zdroj a datastore pre tabu\u013Eku {0} boli aktualizované 
+dpu.resource.created = Zdroj a datastore {0} boli vytvorené
+dpu.resource.updated = Zdroj a datastore {0} boli aktualizované 
 
 # Errors
 errors.dpu.failed = Vykonávanie kroku zlyhalo
 errors.tables.iterator = Nepodarilo sa na\u010Díta\u0165 vstupné databázové tabu\u013Eky
-dpu.resource.skipped.short = Vytváranie zdroja pre tabu\u013Eku {0} vynechané
+dpu.resource.skipped.short = Vytváranie zdroja {0} vynechané
 dpu.resource.skipped.long = Zdroj bol vynechaný, preto\u017Ee u\u017E existuje v katalógu a prepisovací mód nie je zapnutý
-dpu.resource.upload = Nepodarilo sa vytvori\u0165 zdroj a datastore pre databázovú tabu\u013Eku {0}
+dpu.resource.upload = Nepodarilo sa vytvori\u0165 zdroj a datastore {0} pre databázovú tabu\u013Eku {1}
 errors.dpu.upload = Nastala interná chyba pri vytváraní katalógových zdrojov zo vstupných tabuliek   
 errors.dpu.dataset = Nepodarilo sa získa\u0165 zoznam existujúcich zdrojov pre tento proces
 dpu.resource.dataseterror = Nepodarilo sa získa\u0165 Dataset z CKAN. Odpove\u010F: {0}
 errors.token.missing = Chýba autentifika\u010Dný token pre katalógové API
 errors.api.missing = Chýba URL lokácie katalógového API
+errors.input.tables = Nesprávny po\u010Det tabuliek na vstupe kroku. Krok mô\u017Ee spracova\u0165 len jednu tabu\u013Eku
 dpu.resource.responseerror = CKAN odpovedal, \u017Ee operácia bola neúspe\u0161ná. Pre podrobnosti prezrite logy

--- a/src/main/resources/resources_sk.properties
+++ b/src/main/resources/resources_sk.properties
@@ -2,7 +2,7 @@
 dialog.ckan.overwrite = Prepísa\u0165 existujúce zdroje
 dialog.ckan.resource.name = Názov zdroja v CKANe
 dialog.errors.params = Chýbajú povinné konfigura\u010Dné parametre
-
+dialog.resource.name.help = Tento názov by sa nemal meni\u0165 medzi jednotlivými behmi procesu. Názov zdroja je pou\u017Eitý ako k\u013Eú\u010D do CKANu. Ak sa názov zmení, zdroj v CKANe nebude aktualizovaný a bude vytvorený v\u017Edy nový
 
 # Messages
 dpu.ckan.starting = {0} \u0161tartuje.


### PR DESCRIPTION
Fixed conversion of data types from internal UV database (H2) to CKAN (PostgreSQL).
Added new mandatory parameter for CKAN resource name; Now user must provide name for CKAN resource and DPU can process only one input databse table (fails if user attempts to process multiple tables)
